### PR TITLE
use resolution blueprint when translating

### DIFF
--- a/lib/absinthe/compose/http_client.ex
+++ b/lib/absinthe/compose/http_client.ex
@@ -1,9 +1,7 @@
 defmodule Absinthe.Compose.HTTPClient do
   require Logger
 
-  def init(opts), do: opts
-
-  def resolve(opts, query, variables) do
+  def resolve(query, variables, opts, _resolution) do
     url = Keyword.fetch!(opts, :url)
 
     headers =


### PR DESCRIPTION
I found 2 cases recently that were problematic.

First, if I returned a `null` at the top-level query object, we were still trying to walk through the fields of that object based on the composed schema's definition of its fields.

Second, if a nested field had a name like `favorite_paddle`, it would come back from the downstream request as `favoritePaddle`, but we were using the field name as it appears in our composed schema.

Both of these issues could be fixed by switching how we translate downstream data. This PR switches to the using the `resolution` which represents the query made by the client rather than using our internal representation of the schema.