### PR TITLE
Fix support for boolean fields

### DIFF
--- a/lib/absinthe/compose/downstream.ex
+++ b/lib/absinthe/compose/downstream.ex
@@ -57,6 +57,10 @@ defmodule Absinthe.Compose.Downstream do
     downstream
   end
 
+  def translate_scalar(downstream, %Absinthe.Type.Scalar{identifier: :boolean}) do
+    downstream
+  end
+
   def translate_scalar(downstream, %Absinthe.Type.Enum{} = enum) do
     case Map.get(enum.values_by_name, downstream) do
       nil -> raise "Invalid Enum value #{inspect(downstream)} for #{enum.name}"

--- a/test/proxy_query_field_test.exs
+++ b/test/proxy_query_field_test.exs
@@ -36,6 +36,7 @@ defmodule Absinthe.Compose.ProxyQueryFieldTest do
     object :player do
       field(:name, non_null(:id))
       field(:key, :string)
+      field(:active, :boolean)
       field(:favorite_paddle, :paddle)
     end
 
@@ -78,6 +79,7 @@ defmodule Absinthe.Compose.ProxyQueryFieldTest do
     player(key: $key) {
       key
       name
+      active
       favoritePaddle {
         name
         quality
@@ -105,6 +107,7 @@ defmodule Absinthe.Compose.ProxyQueryFieldTest do
 
     assert data == %{
              "player" => %{
+               "active" => true,
                "key" => "SL",
                "name" => "Star Lord",
                "favoritePaddle" => %{

--- a/test/support/pong/schema.ex
+++ b/test/support/pong/schema.ex
@@ -9,9 +9,9 @@ defmodule Pong.Schema do
   ]
 
   @players [
-    %{name: "Star Lord", key: "SL", favorite_paddle: Enum.at(@paddles, 0)},
-    %{name: "Code Cowboy", key: "🤠", favorite_paddle: Enum.at(@paddles, 2)},
-    %{name: "Obi Wan", key: "OW", favorite_paddle: Enum.at(@paddles, 3)}
+    %{active: true, name: "Star Lord", key: "SL", favorite_paddle: Enum.at(@paddles, 0)},
+    %{active: true, name: "Code Cowboy", key: "🤠", favorite_paddle: Enum.at(@paddles, 2)},
+    %{active: false, name: "Obi Wan", key: "OW", favorite_paddle: Enum.at(@paddles, 3)}
   ]
 
   query do
@@ -59,6 +59,7 @@ defmodule Pong.Schema do
   end
 
   object :player do
+    field(:active, :boolean)
     field(:name, non_null(:id))
     field(:key, :string)
     field(:favorite_paddle, :paddle)


### PR DESCRIPTION
Hi 👋🏻 

I'm doing some experiments with this library (Nice work here 💪🏻 ) and I found this small issue.

## Issue
In case there is a boolean field, this lib will thrown the following error:

```
Request: POST /graphiql
** (exit) an exception was raised:
    ** (RuntimeError) Not sure how to translate false to %Absinthe.Type.Scalar{..., identifier: :boolean}
```

This commit aims to fix that.